### PR TITLE
Remove harcoded appname in redis_envvars.sh

### DIFF
--- a/redis_envvars.sh
+++ b/redis_envvars.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env sh
 
-dokku redis:info redis_alfa > /tmp/redis_info
+app_name=$1
+
+dokku redis:info redis_${app_name} > /tmp/redis_info
 
 redis_host="$(grep -o -P '(?<=@).*(?=:)' /tmp/redis_info)"
 redis_port="$(grep -o -P '(?<=:)(\d+)(?!.*\d)(?=$)' /tmp/redis_info)"
 redis_host_password="$(grep -o -P '(?<=\/\/:).*(?=@)' /tmp/redis_info)"
 
-dokku config:set alfa REDIS_HOST=$redis_host REDIS_HOST_PASSWORD=$redis_host_password REDIS_PORT=$redis_port
+dokku config:set ${app_name} REDIS_HOST=$redis_host REDIS_HOST_PASSWORD=$redis_host_password REDIS_PORT=$redis_port

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,7 @@
     service: redis
 
 - name: Get Redis environment variables to config NextCloud
-  script: ../redis_envvars.sh
+  script: ../redis_envvars.sh "{{ app_name }}"
 
 - name: Pull and deploy Nextcloud
   dokku_image:


### PR DESCRIPTION
Fixes #6

- Now appname is a parameter sent by the ansible task.